### PR TITLE
Update MileXamlBlankAppNetFrameworkModern project

### DIFF
--- a/Mile.Xaml.Samples.sln
+++ b/Mile.Xaml.Samples.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MileXamlBlankAppNetNative",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MileXamlBlankAppNetFramework", "MileXamlBlankAppNetFramework\MileXamlBlankAppNetFramework.csproj", "{EE6C5A2A-5CAC-467C-B8CC-9C14159D1A4D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MileXamlBlankAppNetFrameworkModern", "MileXamlBlankAppNetFrameworkModern\MileXamlBlankAppNetFrameworkModern.csproj", "{58DCE199-78EF-4D81-A632-10B4C93E02FB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM64 = Debug|ARM64
@@ -75,6 +77,18 @@ Global
 		{EE6C5A2A-5CAC-467C-B8CC-9C14159D1A4D}.Release|x64.Build.0 = Release|x64
 		{EE6C5A2A-5CAC-467C-B8CC-9C14159D1A4D}.Release|x86.ActiveCfg = Release|Any CPU
 		{EE6C5A2A-5CAC-467C-B8CC-9C14159D1A4D}.Release|x86.Build.0 = Release|Any CPU
+		{58DCE199-78EF-4D81-A632-10B4C93E02FB}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{58DCE199-78EF-4D81-A632-10B4C93E02FB}.Debug|ARM64.Build.0 = Debug|ARM64
+		{58DCE199-78EF-4D81-A632-10B4C93E02FB}.Debug|x64.ActiveCfg = Debug|x64
+		{58DCE199-78EF-4D81-A632-10B4C93E02FB}.Debug|x64.Build.0 = Debug|x64
+		{58DCE199-78EF-4D81-A632-10B4C93E02FB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{58DCE199-78EF-4D81-A632-10B4C93E02FB}.Debug|x86.Build.0 = Debug|Any CPU
+		{58DCE199-78EF-4D81-A632-10B4C93E02FB}.Release|ARM64.ActiveCfg = Release|ARM64
+		{58DCE199-78EF-4D81-A632-10B4C93E02FB}.Release|ARM64.Build.0 = Release|ARM64
+		{58DCE199-78EF-4D81-A632-10B4C93E02FB}.Release|x64.ActiveCfg = Release|x64
+		{58DCE199-78EF-4D81-A632-10B4C93E02FB}.Release|x64.Build.0 = Release|x64
+		{58DCE199-78EF-4D81-A632-10B4C93E02FB}.Release|x86.ActiveCfg = Release|Any CPU
+		{58DCE199-78EF-4D81-A632-10B4C93E02FB}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/MileXamlBlankAppNetFramework/MileXamlBlankAppNetFramework.csproj
+++ b/MileXamlBlankAppNetFramework/MileXamlBlankAppNetFramework.csproj
@@ -17,15 +17,11 @@
     <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
     <TargetFrameworkIdentifier>.NETFramework</TargetFrameworkIdentifier>
     <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
-    <SDKIdentifier>Windows</SDKIdentifier>
-    <SDKVersion>10.0</SDKVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
     <ApplicationManifest>Properties\App.manifest</ApplicationManifest>
     <LangVersion>latest</LangVersion>
-    <!-- Remove Microsoft.UI.Xaml.Markup -->
-    <EnableTypeInfoReflection>false</EnableTypeInfoReflection>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugSymbols>true</DebugSymbols>
@@ -81,19 +77,11 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.SDK.Contracts">
-      <Version>10.0.22621.755</Version>
+      <Version>$(TargetPlatformVersion.TrimEnd('.0')).*</Version>
+    </PackageReference>
+    <PackageReference Include="Mile.Xaml">
+      <Version>1000.0.0.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\8.21\Microsoft.Windows.UI.Xaml.Common.targets" />
-  <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\8.21\Microsoft.Windows.UI.Xaml.Cps.targets" />
-  <ItemGroup>
-    <Reference Include="C:\Users\*\.nuget\packages\mile.xaml\1.1.434\lib\uap10.0\Mile.Xaml.winmd">
-      <Implementation>Mile.Xaml.dll</Implementation>
-    </Reference>
-    <ReferenceCopyLocalPaths Include="C:\Users\*\.nuget\packages\mile.xaml\1.1.434\runtimes\win10-$(Platform)\native\Mile.Xaml.dll" />
-    <ReferenceCopyLocalPaths Include="C:\Users\*\.nuget\packages\mile.xaml\1.1.434\runtimes\win10-$(Platform)\native\Mile.Xaml.pdb" />
-    <ReferenceCopyLocalPaths Include="C:\Users\*\.nuget\packages\mile.xaml\1.1.434\runtimes\win10-$(Platform)\native\Mile.Xaml.Styles.SunValley.xbf" />
-  </ItemGroup>
-  <Import Project="C:\Users\*\.nuget\packages\mile.xaml\1.1.434\build\native\MrtCore.PriGen.targets" />
 </Project>

--- a/MileXamlBlankAppNetFramework/PInvoke.cs
+++ b/MileXamlBlankAppNetFramework/PInvoke.cs
@@ -26,15 +26,6 @@ namespace Native.Win32.System.LibraryLoader
 
 namespace Native.Win32.System.Threading
 {
-    public static class Process
-    {
-        [DllImport(
-            "Kernel32.dll",
-            CharSet = CharSet.Unicode,
-            ExactSpelling = true)]
-        public static extern void ExitProcess([In] uint uExitCode);
-    }
-
     public static class Startup
     {
         [Flags]

--- a/MileXamlBlankAppNetFrameworkModern/App.manifest
+++ b/MileXamlBlankAppNetFrameworkModern/App.manifest
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <maxversiontested Id="10.0.18362.0"/>
+      <maxversiontested Id="10.0.19041.0"/>
+      <maxversiontested Id="10.0.20348.0"/>
+      <maxversiontested Id="10.0.22000.0"/>
+      <maxversiontested Id="10.0.22621.0"/>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <autoElevate xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">False</autoElevate>
+      <disableTheming xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">False</disableTheming>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">True/PM</dpiAware>
+      <disableWindowFiltering xmlns="http://schemas.microsoft.com/SMI/2011/WindowsSettings">True</disableWindowFiltering>
+      <printerDriverIsolation xmlns="http://schemas.microsoft.com/SMI/2011/WindowsSettings">True</printerDriverIsolation>
+      <highResolutionScrollingAware xmlns="http://schemas.microsoft.com/SMI/2013/WindowsSettings">True</highResolutionScrollingAware>
+      <ultraHighResolutionScrollingAware xmlns="http://schemas.microsoft.com/SMI/2013/WindowsSettings">True</ultraHighResolutionScrollingAware>
+      <forceFocusBasedMouseWheel xmlns="http://schemas.microsoft.com/SMI/2014/WindowsSettings">False</forceFocusBasedMouseWheel>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor, System, Unaware</dpiAwareness>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">True</longPathAware>
+      <gdiScaling xmlns="http://schemas.microsoft.com/SMI/2017/WindowsSettings">False</gdiScaling>
+      <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+      <heapType xmlns="http://schemas.microsoft.com/SMI/2020/WindowsSettings">SegmentHeap</heapType>
+    </windowsSettings>
+  </application>
+
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0" processorArchitecture="*" publicKeyToken="6595b64144ccf1df" language="*" />
+    </dependentAssembly>
+  </dependency>
+
+  <file name="Mile.Xaml.dll">
+    <activatableClass xmlns="urn:schemas-microsoft-com:winrt.v1" name="Mile.Xaml.Application" threadingModel="both" />
+    <activatableClass xmlns="urn:schemas-microsoft-com:winrt.v1" name="Mile.Xaml.XamlControlsResources" threadingModel="both" />
+  </file>
+
+</assembly>

--- a/MileXamlBlankAppNetFrameworkModern/App.xaml
+++ b/MileXamlBlankAppNetFrameworkModern/App.xaml
@@ -1,0 +1,13 @@
+﻿<MileXaml:Application
+  x:Class="MileXamlBlankAppNetFrameworkModern.App"
+  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:MileXaml="using:Mile.Xaml">
+  <Application.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <MileXaml:XamlControlsResources />
+      </ResourceDictionary.MergedDictionaries>
+    </ResourceDictionary>
+  </Application.Resources>
+</MileXaml:Application>

--- a/MileXamlBlankAppNetFrameworkModern/App.xaml.cs
+++ b/MileXamlBlankAppNetFrameworkModern/App.xaml.cs
@@ -1,0 +1,9 @@
+﻿using Mile.Xaml;
+
+namespace MileXamlBlankAppNetFrameworkModern
+{
+    sealed partial class App : Application
+    {
+        public App() => this.Initialize();
+    }
+}

--- a/MileXamlBlankAppNetFrameworkModern/MainPage.xaml
+++ b/MileXamlBlankAppNetFrameworkModern/MainPage.xaml
@@ -1,0 +1,19 @@
+﻿<Page
+  x:Class="MileXamlBlankAppNetFrameworkModern.MainPage"
+  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+  mc:Ignorable="d">
+  <Page.Content>
+    <Grid
+      HorizontalAlignment="Center"
+      VerticalAlignment="Center">
+      <Grid.Children>
+        <Button
+          Content="Click Me"
+          Click="Button_Click" />
+      </Grid.Children>
+    </Grid>
+  </Page.Content>
+</Page>

--- a/MileXamlBlankAppNetFrameworkModern/MainPage.xaml.cs
+++ b/MileXamlBlankAppNetFrameworkModern/MainPage.xaml.cs
@@ -1,0 +1,18 @@
+﻿using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace MileXamlBlankAppNetFrameworkModern
+{
+    public sealed partial class MainPage : Page
+    {
+        public MainPage()
+        {
+            this.InitializeComponent();
+        }
+
+        private void Button_Click(object sender, RoutedEventArgs _)
+        {
+            (sender as Button).Content = "Clicked";
+        }
+    }
+}

--- a/MileXamlBlankAppNetFrameworkModern/MileXamlBlankAppNetFramework.csproj
+++ b/MileXamlBlankAppNetFrameworkModern/MileXamlBlankAppNetFramework.csproj
@@ -1,0 +1,99 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <PlatformTarget Condition="'$(Platform)' == 'x86'">x86</PlatformTarget>
+    <PlatformTarget Condition="'$(Platform)' == 'x64'">x64</PlatformTarget>
+    <PlatformTarget Condition="'$(Platform)' == 'ARM64'">ARM64</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ProjectGuid>{EE6C5A2A-5CAC-467C-B8CC-9C14159D1A4D}</ProjectGuid>
+    <OutputType>WinExe</OutputType>
+    <RootNamespace>MileXamlBlankAppNetFramework</RootNamespace>
+    <AssemblyName>MileXamlBlankAppNetFramework</AssemblyName>
+    <DefaultLanguage>en-us</DefaultLanguage>
+    <TargetPlatformIdentifier>Windows</TargetPlatformIdentifier>
+    <TargetPlatformVersion>10.0.22621.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
+    <TargetFrameworkIdentifier>.NETFramework</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
+    <SDKIdentifier>Windows</SDKIdentifier>
+    <SDKVersion>10.0</SDKVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+    <ApplicationManifest>Properties\App.manifest</ApplicationManifest>
+    <LangVersion>latest</LangVersion>
+    <!-- Remove Microsoft.UI.Xaml.Markup -->
+    <EnableTypeInfoReflection>false</EnableTypeInfoReflection>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath Condition="'$(OutputPath)' == ''">bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;DISABLE_XAML_GENERATED_MAIN</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath Condition="'$(OutputPath)' == ''">bin\Release\</OutputPath>
+    <DefineConstants>TRACE;DISABLE_XAML_GENERATED_MAIN</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="App.xaml.cs">
+      <DependentUpon>App.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="MainPage.xaml.cs">
+      <DependentUpon>MainPage.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="PInvoke.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ApplicationDefinition Include="App.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </ApplicationDefinition>
+    <Page Include="MainPage.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Properties\App.config" />
+    <None Include="Properties\App.manifest" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Windows.SDK.Contracts">
+      <Version>10.0.22621.755</Version>
+    </PackageReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\8.21\Microsoft.Windows.UI.Xaml.Common.targets" />
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\8.21\Microsoft.Windows.UI.Xaml.Cps.targets" />
+  <ItemGroup>
+    <Reference Include="C:\Users\*\.nuget\packages\mile.xaml\1.1.434\lib\uap10.0\Mile.Xaml.winmd">
+      <Implementation>Mile.Xaml.dll</Implementation>
+    </Reference>
+    <ReferenceCopyLocalPaths Include="C:\Users\*\.nuget\packages\mile.xaml\1.1.434\runtimes\win10-$(Platform)\native\Mile.Xaml.dll" />
+    <ReferenceCopyLocalPaths Include="C:\Users\*\.nuget\packages\mile.xaml\1.1.434\runtimes\win10-$(Platform)\native\Mile.Xaml.pdb" />
+    <ReferenceCopyLocalPaths Include="C:\Users\*\.nuget\packages\mile.xaml\1.1.434\runtimes\win10-$(Platform)\native\Mile.Xaml.Styles.SunValley.xbf" />
+  </ItemGroup>
+  <Import Project="C:\Users\*\.nuget\packages\mile.xaml\1.1.434\build\native\MrtCore.PriGen.targets" />
+</Project>

--- a/MileXamlBlankAppNetFrameworkModern/MileXamlBlankAppNetFrameworkModern.csproj
+++ b/MileXamlBlankAppNetFrameworkModern/MileXamlBlankAppNetFrameworkModern.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Platforms>x86;x64;ARM64</Platforms>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net481</TargetFramework>
+    <TargetPlatformVersion>10.0.22621.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
+    <LangVersion>latest</LangVersion>
+    <ApplicationManifest>App.manifest</ApplicationManifest>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Windows.SDK.Contracts" Version="$(TargetPlatformVersion.TrimEnd('.0')).*" />
+    <PackageReference Include="Mile.Xaml" Version="1000.0.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/MileXamlBlankAppNetFrameworkModern/PInvoke.cs
+++ b/MileXamlBlankAppNetFrameworkModern/PInvoke.cs
@@ -1,0 +1,223 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Native.Win32.System.Console
+{
+    public static class Text
+    {
+        [Flags]
+        public enum CharacterAttributes : ushort { }
+    }
+}
+
+namespace Native.Win32.System.LibraryLoader
+{
+    public static class Module
+    {
+        [DllImport(
+            "Kernel32.dll",
+            CharSet = CharSet.Unicode,
+            ExactSpelling = true,
+            SetLastError = true)]
+        public static extern IntPtr GetModuleHandleW(
+            [In][Optional] string lpModuleName);
+    }
+}
+
+namespace Native.Win32.System.Threading
+{
+    public static class Startup
+    {
+        [Flags]
+        public enum Flag : uint { }
+
+        [StructLayout(
+            LayoutKind.Sequential,
+            CharSet = CharSet.Unicode)]
+        public struct InfoW
+        {
+            public uint cb;
+            public IntPtr lpReserved;
+            public IntPtr lpDesktop;
+            public IntPtr lpTitle;
+            public uint dwX;
+            public uint dwY;
+            public uint dwXSize;
+            public uint dwYSize;
+            public uint dwXCountChars;
+            public uint dwYCountChars;
+            public Console.Text.CharacterAttributes dwFillAttribute;
+            public Flag dwFlags;
+            public UI.WindowsAndMessaging.Window.ShowCmd wShowWindow;
+            public ushort cbReserved2;
+            public IntPtr lpReserved2;
+            public IntPtr hStdInput;
+            public IntPtr hStdOutput;
+            public IntPtr hStdError;
+        }
+
+        [DllImport(
+            "Kernel32.dll",
+            CharSet = CharSet.Unicode,
+            ExactSpelling = true)]
+        public static extern void GetStartupInfoW(
+            [Out] out InfoW lpStartupInfo);
+    }
+}
+
+namespace Native.Win32.UI.Input.KeyboardAndMouse
+{
+    public static class Keyboard
+    {
+        [Flags]
+        public enum Notifications : uint
+        {
+            SysKeyDown = 0x0104
+        }
+
+        [Flags]
+        public enum VirtualKey : ushort
+        {
+            F4 = 0x73
+        }
+    }
+}
+
+namespace Native.Win32.UI.WindowsAndMessaging
+{
+    public static class Message
+    {
+        [StructLayout(LayoutKind.Sequential)]
+        public struct Msg
+        {
+            public IntPtr hwnd;
+            public uint message;
+            public UIntPtr wParam;
+            public IntPtr lParam;
+            public uint time;
+            public Point pt;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct Point
+        {
+            public int x;
+            public int y;
+        }
+
+        [DllImport(
+            "User32.dll",
+            CharSet = CharSet.Unicode,
+            ExactSpelling = true)]
+        public static extern IntPtr DispatchMessageW([In] in Msg lpMsg);
+
+        [DllImport(
+            "User32.dll",
+            CharSet = CharSet.Unicode,
+            ExactSpelling = true,
+            SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool GetMessageW(
+            [Out] out Msg lpMsg,
+            [In][Optional] IntPtr hWnd,
+            [In] uint wMsgFilterMin,
+            [In] uint wMsgFilterMax);
+
+        [DllImport(
+            "User32.dll",
+            CharSet = CharSet.Unicode,
+            ExactSpelling = true)]
+        public static extern IntPtr SendMessageW(
+            [In] IntPtr hWnd,
+            [In] uint Msg,
+            [In][Optional] UIntPtr wParam,
+            [In][Optional] IntPtr lParam);
+
+        [DllImport(
+            "User32.dll",
+            CharSet = CharSet.Unicode,
+            ExactSpelling = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool TranslateMessage([In] in Msg lpMsg);
+    }
+    public static class Window
+    {
+        [Flags]
+        public enum ExStyle : uint
+        {
+            Left = 0x00000000
+        }
+
+        [Flags]
+        public enum ShowCmd : uint { }
+
+        [Flags]
+        public enum Style : uint
+        {
+            Caption = 0x00C00000,
+            MinimizeBox = 0x00020000,
+            MaximizeBox = 0x00010000,
+            OverLapped = 0x00000000,
+            OverLappedWindow =
+                OverLapped | Caption | SysMenu
+                | ThickFrame | MinimizeBox | MaximizeBox,
+            SysMenu = 0x00080000,
+            ThickFrame = 0x00040000
+        }
+
+        public const int CreateUseDefault = unchecked((int)0x80000000);
+
+        [DllImport(
+            "User32.dll",
+            CharSet = CharSet.Unicode,
+            ExactSpelling = true,
+            SetLastError = true)]
+        public static extern IntPtr CreateWindowExW(
+            [In] ExStyle dwExStyle,
+            [In][Optional] string lpClassName,
+            [In][Optional] string lpWindowName,
+            [In] Style dwStyle,
+            [In] int X,
+            [In] int Y,
+            [In] int nWidth,
+            [In] int nHeight,
+            [In][Optional] IntPtr hWndParent,
+            [In][Optional] IntPtr hMenu,
+            [In][Optional] IntPtr hInstance,
+            [In][Optional] IntPtr lpParam);
+
+        [DllImport(
+            "User32.dll",
+            CharSet = CharSet.Unicode,
+            ExactSpelling = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool ShowWindow(
+            [In] IntPtr hWnd,
+            [In] ShowCmd nCmdShow);
+
+        [DllImport(
+            "User32.dll",
+            CharSet = CharSet.Unicode,
+            ExactSpelling = true,
+            SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool UpdateWindow([In] IntPtr hWnd);
+
+        public static class Ancestor
+        {
+            [Flags]
+            public enum Flag : uint
+            {
+                Root = 2
+            }
+
+            [DllImport(
+                "User32.dll",
+                CharSet = CharSet.Unicode,
+                ExactSpelling = true)]
+            public static extern IntPtr GetAncestor(
+                [In] IntPtr hwnd,
+                [In] Flag gaFlags);
+        }
+    }
+}

--- a/MileXamlBlankAppNetFrameworkModern/Program.cs
+++ b/MileXamlBlankAppNetFrameworkModern/Program.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using Native.Win32.System.LibraryLoader;
+using Native.Win32.System.Threading;
+using Native.Win32.UI.Input.KeyboardAndMouse;
+using Native.Win32.UI.WindowsAndMessaging;
+
+namespace MileXamlBlankAppNetFrameworkModern
+{
+    public static class Program
+    {
+        [STAThread]
+        public static int Main()
+        {
+            App app = new();
+
+            var hWnd = Window.CreateWindowExW(
+                dwExStyle: Window.ExStyle.Left,
+                lpClassName: "Mile.Xaml.ContentWindow",
+                lpWindowName: "MileXamlBlankApp (.Net Framework)",
+                dwStyle: Window.Style.OverLappedWindow,
+                X: Window.CreateUseDefault,
+                Y: 0,
+                nWidth: Window.CreateUseDefault,
+                nHeight: 0,
+                hInstance: Module.GetModuleHandleW(null),
+                lpParam: Marshal.GetIUnknownForObject(new MainPage()));
+            if (hWnd == IntPtr.Zero)
+            {
+                return -1;
+            }
+
+            Startup.InfoW info = new();
+            info.cb = (uint)Marshal.SizeOf(info);
+            Startup.GetStartupInfoW(out info);
+
+            Window.ShowWindow(hWnd, info.wShowWindow);
+            Window.UpdateWindow(hWnd);
+
+            Message.Msg msg;
+            while (Message.GetMessageW(
+                lpMsg: out msg,
+                wMsgFilterMin: 0,
+                wMsgFilterMax: 0))
+            {
+                if (msg.message == (uint)Keyboard.Notifications.SysKeyDown
+                    && msg.wParam == (UIntPtr)Keyboard.VirtualKey.F4)
+                {
+                    Message.SendMessageW(
+                        Window.Ancestor.GetAncestor(
+                            hWnd,
+                            Window.Ancestor.Flag.Root),
+                        msg.message,
+                        msg.wParam,
+                        msg.lParam);
+                    continue;
+                }
+
+                Message.TranslateMessage(in msg);
+                Message.DispatchMessageW(in msg);
+            }
+
+            app.Dispose();
+            // Due to the design of .Net Native, the program won't exit when returning a number.
+            return unchecked((int)msg.wParam.ToUInt32());
+        }
+    }
+}

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -22,3 +22,13 @@ modernized Windows 11 style XAML controls.
 
 A project for a single page C# (.Net Native) XAML Islands app with Mile.Xaml and no
 predefined layout.
+
+### [MileXamlBlankAppNetFramework](MileXamlBlankAppNetFramework)
+
+A project (MsBuild Style Project) for a single page C# (.Net Framework) XAML Islands app with Mile.Xaml and no
+predefined layout.
+
+### [MileXamlBlankAppNetFrameworkModern](MileXamlBlankAppNetFrameworkModern)
+
+A project (.Net SDK Style Project) for a single page C# (.Net Framework) XAML Islands app with Mile.Xaml and no
+predefined layout.


### PR DESCRIPTION
Need add these props in Mile.Xaml Nuget Package
```
<!-- Use Windows 10 SDK instead of 7/8.x -->
<SDKIdentifier>Windows</SDKIdentifier>
<SDKVersion>10.0</SDKVersion>
<DefineConstants>$(DefineConstants);DISABLE_XAML_GENERATED_MAIN</DefineConstants>
<!-- Remove Microsoft.UI.Xaml.Markup -->
<EnableTypeInfoReflection>false</EnableTypeInfoReflection>
<!-- Generate Default XAML Items for .Net SDK Style Project -->
<_EnableWindowsDesktopGlobbing Condition="'$(UsingMicrosoftNETSdk)' == 'true'">true</_EnableWindowsDesktopGlobbing>
<!-- Enable XAML Compiler, not using targets not located in 8.21, due to prevent the impact of UWP Toolchain and support .Net SDK Style project -->
<CustomAfterMicrosoftCSharpTargets>
  $(CustomAfterMicrosoftCSharpTargets);
  $(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\8.21\Microsoft.Windows.UI.Xaml.Common.targets;
  $(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\8.21\Microsoft.Windows.UI.Xaml.Cps.targets;
</CustomAfterMicrosoftCSharpTargets>
```

Add these props in Directory.Build.props
```
<PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.csproj'">
  <!-- Workaround for WPF -->
  <MSBuildProjectName>$(MSBuildProjectName.Split("_")[0])</MSBuildProjectName>
  <MSBuildProjectExtensionsPath></MSBuildProjectExtensionsPath>
  <AppxPackageDir></AppxPackageDir>
  <!-- Use for .Net SDK -->
  <BaseOutputPath Condition="'$(UsingMicrosoftNETSdk)' == 'true'"></BaseOutputPath>
  <BaseIntermediateOutputPath Condition="'$(UsingMicrosoftNETSdk)' == 'true'"></BaseIntermediateOutputPath>
  <!-- Use for Legacy -->
  <OutputPath Condition="'$(UsingMicrosoftNETSdk)' != 'true'"></OutputPath>
  <IntermediateOutputPath Condition="'$(UsingMicrosoftNETSdk)' != 'true'"></IntermediateOutputPath>
  <!-- Use for .Net Native -->
  <IlcOutputPath Condition="'$(UseDotNetNativeToolchain)' == 'true'"></IlcOutputPath>
  <IlcIntermediateRootPath Condition="'$(UseDotNetNativeToolchain)' == 'true'"></IlcIntermediateRootPath>
</PropertyGroup>

<PropertyGroup>
  <RuntimeIdentifiers>win;win-x86;win-x64;win-arm;win-arm64;win10-x86;win10-x64;win10-arm;win10-arm64;win10-x86-aot;win10-x64-aot;win10-arm-aot;win10-arm64-aot</RuntimeIdentifiers>
</PropertyGroup>
```