### PR TITLE
Use GeneratedComInterface to define IGraphicsEffectD2D1Interop

### DIFF
--- a/MileXamlControlsDemoNetCore/UI/Backdrop/BlendEffect.cs
+++ b/MileXamlControlsDemoNetCore/UI/Backdrop/BlendEffect.cs
@@ -2,31 +2,22 @@
 using MileXamlControlsDemoNetCore.WindowsAPI.ComTypes;
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Windows.Graphics.Effects;
+using WinRT;
 
 namespace MileXamlControlsDemoNetCore.UI.Backdrop
 {
-    [Guid("81C5B77B-13F8-4CDD-AD20-C890547AC65D")]
+    [GeneratedComClass, Guid("81C5B77B-13F8-4CDD-AD20-C890547AC65D")]
     public sealed partial class BlendEffect : IGraphicsEffect, IGraphicsEffectSource, IGraphicsEffectD2D1Interop
     {
-        public D2D1_BUFFER_PRECISION BufferPrecision { get; set; }
-
-        public bool CacheOutput { get; set; }
-
         public BlendEffectMode Mode { get; set; } = BlendEffectMode.Multiply;
+
+        public string Name { get; set; } = string.Empty;
 
         public IGraphicsEffectSource Background { get; set; }
 
         public IGraphicsEffectSource Foreground { get; set; }
-
-        private string _name = string.Empty;
-
-        public string Name
-        {
-            get { return _name; }
-
-            set { _name = value; }
-        }
 
         public int GetEffectId(out Guid id)
         {
@@ -34,9 +25,9 @@ namespace MileXamlControlsDemoNetCore.UI.Backdrop
             return 0;
         }
 
-        public int GetNamedPropertyMapping(IntPtr name, out uint index, out GRAPHICS_EFFECT_PROPERTY_MAPPING mapping)
+        public int GetNamedPropertyMapping(string name, out uint index, out GRAPHICS_EFFECT_PROPERTY_MAPPING mapping)
         {
-            switch (Marshal.PtrToStringUni(name))
+            switch (name)
             {
                 case nameof(Mode):
                     {
@@ -51,6 +42,7 @@ namespace MileXamlControlsDemoNetCore.UI.Backdrop
                         break;
                     }
             }
+
             return 0;
         }
 
@@ -65,6 +57,7 @@ namespace MileXamlControlsDemoNetCore.UI.Backdrop
                     return 0;
                 }
             }
+
             source = IntPtr.Zero;
             return -2147483637;
         }
@@ -75,21 +68,21 @@ namespace MileXamlControlsDemoNetCore.UI.Backdrop
             return 0;
         }
 
-        public int GetSource(uint index, out IGraphicsEffectSource source)
+        public int GetSource(uint index, out IntPtr source)
         {
             if (index is 0)
             {
-                source = Background;
+                source = MarshalInterface<IGraphicsEffectSource>.FromManaged(Background);
                 return 0;
             }
             else if (index is 1)
             {
-                source = Foreground;
+                source = MarshalInterface<IGraphicsEffectSource>.FromManaged(Foreground);
                 return 0;
             }
             else
             {
-                source = null;
+                source = IntPtr.Zero;
                 return 2147483637;
             }
         }

--- a/MileXamlControlsDemoNetCore/UI/Backdrop/BorderEffect.cs
+++ b/MileXamlControlsDemoNetCore/UI/Backdrop/BorderEffect.cs
@@ -2,16 +2,16 @@
 using MileXamlControlsDemoNetCore.WindowsAPI.ComTypes;
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Windows.Graphics.Effects;
+using WinRT;
 
 namespace MileXamlControlsDemoNetCore.UI.Backdrop
 {
-    [Guid("2A2D49C0-4ACF-43C7-8C6A-7C4A27874D27")]
-    public partial class BorderEffect : IGraphicsEffect, IGraphicsEffectSource, IGraphicsEffectD2D1Interop
+    [GeneratedComClass, Guid("2A2D49C0-4ACF-43C7-8C6A-7C4A27874D27")]
+    public sealed partial class BorderEffect : IGraphicsEffect, IGraphicsEffectSource, IGraphicsEffectD2D1Interop
     {
-        public D2D1_BUFFER_PRECISION BufferPrecision { get; set; }
-
-        public bool CacheOutput { get; set; }
+        public string Name { get; set; } = string.Empty;
 
         public CanvasEdgeBehavior ExtendX { get; set; } = CanvasEdgeBehavior.Clamp;
 
@@ -19,24 +19,15 @@ namespace MileXamlControlsDemoNetCore.UI.Backdrop
 
         public IGraphicsEffectSource Source { get; set; }
 
-        private string _name = string.Empty;
-
-        public string Name
-        {
-            get { return _name; }
-
-            set { _name = value; }
-        }
-
         public int GetEffectId(out Guid id)
         {
             id = typeof(BorderEffect).GUID;
             return 0;
         }
 
-        public int GetNamedPropertyMapping(IntPtr name, out uint index, out GRAPHICS_EFFECT_PROPERTY_MAPPING mapping)
+        public int GetNamedPropertyMapping(string name, out uint index, out GRAPHICS_EFFECT_PROPERTY_MAPPING mapping)
         {
-            switch (Marshal.PtrToStringUni(name))
+            switch (name)
             {
                 case nameof(ExtendX):
                     {
@@ -57,6 +48,7 @@ namespace MileXamlControlsDemoNetCore.UI.Backdrop
                         break;
                     }
             }
+
             return 0;
         }
 
@@ -82,6 +74,7 @@ namespace MileXamlControlsDemoNetCore.UI.Backdrop
                     return 0;
                 }
             }
+
             source = IntPtr.Zero;
             return -2147483637;
         }
@@ -92,16 +85,16 @@ namespace MileXamlControlsDemoNetCore.UI.Backdrop
             return 0;
         }
 
-        public int GetSource(uint index, out IGraphicsEffectSource source)
+        public int GetSource(uint index, out IntPtr source)
         {
             if (index is 0)
             {
-                source = Source;
+                source = MarshalInterface<IGraphicsEffectSource>.FromManaged(Source);
                 return 0;
             }
             else
             {
-                source = null;
+                source = IntPtr.Zero;
                 return 2147483637;
             }
         }

--- a/MileXamlControlsDemoNetCore/UI/Backdrop/ColorSourceEffect.cs
+++ b/MileXamlControlsDemoNetCore/UI/Backdrop/ColorSourceEffect.cs
@@ -1,37 +1,19 @@
 ﻿using MileXamlControlsDemoNetCore.Helpers;
 using MileXamlControlsDemoNetCore.WindowsAPI.ComTypes;
 using System;
-using System.Numerics;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Windows.Graphics.Effects;
 using Windows.UI;
 
 namespace MileXamlControlsDemoNetCore.UI.Backdrop
 {
-    [Guid("61C23C20-AE69-4D8E-94CF-50078DF638F2")]
+    [GeneratedComClass, Guid("61C23C20-AE69-4D8E-94CF-50078DF638F2")]
     public sealed partial class ColorSourceEffect : IGraphicsEffect, IGraphicsEffectSource, IGraphicsEffectD2D1Interop
     {
-        public D2D1_BUFFER_PRECISION BufferPrecision { get; set; }
-
-        public bool CacheOutput { get; set; }
+        public string Name { get; set; } = string.Empty;
 
         public Color Color { get; set; } = Color.FromArgb(255, 255, 255, 255);
-
-        private string _name = string.Empty;
-
-        public string Name
-        {
-            get { return _name; }
-
-            set { _name = value; }
-        }
-
-        public Vector4 ColorHdr
-        {
-            get { return new(Color.R * 255.0f, Color.G * 255.0f, Color.B * 255.0f, Color.A * 255.0f); }
-
-            set { Color = Color.FromArgb((byte)(value.W / 255.0f), (byte)(value.X / 255.0f), (byte)(value.Y / 255.0f), (byte)(value.Z / 255.0f)); }
-        }
 
         public int GetEffectId(out Guid id)
         {
@@ -39,9 +21,9 @@ namespace MileXamlControlsDemoNetCore.UI.Backdrop
             return 0;
         }
 
-        public int GetNamedPropertyMapping(IntPtr name, out uint index, out GRAPHICS_EFFECT_PROPERTY_MAPPING mapping)
+        public int GetNamedPropertyMapping(string name, out uint index, out GRAPHICS_EFFECT_PROPERTY_MAPPING mapping)
         {
-            switch (Marshal.PtrToStringUni(name))
+            switch (name)
             {
                 case nameof(Color):
                     {
@@ -82,9 +64,9 @@ namespace MileXamlControlsDemoNetCore.UI.Backdrop
             return 0;
         }
 
-        public int GetSource(uint index, out IGraphicsEffectSource source)
+        public int GetSource(uint index, out IntPtr source)
         {
-            source = default;
+            source = IntPtr.Zero;
             return 0;
         }
 

--- a/MileXamlControlsDemoNetCore/UI/Backdrop/CompositeEffect.cs
+++ b/MileXamlControlsDemoNetCore/UI/Backdrop/CompositeEffect.cs
@@ -3,27 +3,18 @@ using MileXamlControlsDemoNetCore.WindowsAPI.ComTypes;
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Windows.Graphics.Effects;
+using WinRT;
 
 namespace MileXamlControlsDemoNetCore.UI.Backdrop
 {
-    [Guid("48FC9F51-F6AC-48F1-8B58-3B28AC46F76D")]
-    public partial class CompositeEffect : IGraphicsEffect, IGraphicsEffectSource, IGraphicsEffectD2D1Interop
+    [GeneratedComClass, Guid("48FC9F51-F6AC-48F1-8B58-3B28AC46F76D")]
+    public sealed partial class CompositeEffect : IGraphicsEffect, IGraphicsEffectSource, IGraphicsEffectD2D1Interop
     {
-        public D2D1_BUFFER_PRECISION BufferPrecision { get; set; }
-
-        public bool CacheOutput { get; set; }
+        public string Name { get; set; } = string.Empty;
 
         public CanvasComposite Mode { get; set; } = CanvasComposite.SourceOver;
-
-        private string _name = string.Empty;
-
-        public string Name
-        {
-            get { return _name; }
-
-            set { _name = value; }
-        }
 
         public List<IGraphicsEffectSource> Sources { get; set; } = [];
 
@@ -33,9 +24,9 @@ namespace MileXamlControlsDemoNetCore.UI.Backdrop
             return 0;
         }
 
-        public int GetNamedPropertyMapping(IntPtr name, out uint index, out GRAPHICS_EFFECT_PROPERTY_MAPPING mapping)
+        public int GetNamedPropertyMapping(string name, out uint index, out GRAPHICS_EFFECT_PROPERTY_MAPPING mapping)
         {
-            switch (Marshal.PtrToStringUni(name))
+            switch (name)
             {
                 case nameof(Mode):
                     {
@@ -77,16 +68,16 @@ namespace MileXamlControlsDemoNetCore.UI.Backdrop
             return 0;
         }
 
-        public int GetSource(uint index, out IGraphicsEffectSource source)
+        public int GetSource(uint index, out IntPtr source)
         {
             if (index < Sources.Count)
             {
-                source = Sources[(int)index];
+                source = MarshalInterface<IGraphicsEffectSource>.FromManaged(Sources[(int)index]);
                 return 0;
             }
             else
             {
-                source = null;
+                source = IntPtr.Zero;
                 return 2147483637;
             }
         }

--- a/MileXamlControlsDemoNetCore/UI/Backdrop/CrossFadeEffect.cs
+++ b/MileXamlControlsDemoNetCore/UI/Backdrop/CrossFadeEffect.cs
@@ -2,16 +2,16 @@
 using MileXamlControlsDemoNetCore.WindowsAPI.ComTypes;
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Windows.Graphics.Effects;
+using WinRT;
 
 namespace MileXamlControlsDemoNetCore.UI.Backdrop
 {
-    [Guid("12F575E8-4DB1-485F-9A84-03A07DD3829F")]
+    [GeneratedComClass, Guid("12F575E8-4DB1-485F-9A84-03A07DD3829F")]
     public sealed partial class CrossFadeEffect : IGraphicsEffect, IGraphicsEffectSource, IGraphicsEffectD2D1Interop
     {
-        public D2D1_BUFFER_PRECISION BufferPrecision { get; set; }
-
-        public bool CacheOutput { get; set; }
+        public string Name { get; set; } = string.Empty;
 
         public float CrossFade { get; set; } = 0.5f;
 
@@ -19,24 +19,15 @@ namespace MileXamlControlsDemoNetCore.UI.Backdrop
 
         public IGraphicsEffectSource Source2 { get; set; }
 
-        private string _name = string.Empty;
-
-        public string Name
-        {
-            get { return _name; }
-
-            set { _name = value; }
-        }
-
         public int GetEffectId(out Guid id)
         {
             id = typeof(CrossFadeEffect).GUID;
             return 0;
         }
 
-        public int GetNamedPropertyMapping(IntPtr name, out uint index, out GRAPHICS_EFFECT_PROPERTY_MAPPING mapping)
+        public int GetNamedPropertyMapping(string name, out uint index, out GRAPHICS_EFFECT_PROPERTY_MAPPING mapping)
         {
-            switch (Marshal.PtrToStringUni(name))
+            switch (name)
             {
                 case nameof(CrossFade):
                     {
@@ -77,21 +68,21 @@ namespace MileXamlControlsDemoNetCore.UI.Backdrop
             return 0;
         }
 
-        public int GetSource(uint index, out IGraphicsEffectSource source)
+        public int GetSource(uint index, out IntPtr source)
         {
             if (index is 0)
             {
-                source = Source1;
+                source = MarshalInterface<IGraphicsEffectSource>.FromManaged(Source1);
                 return 0;
             }
             else if (index is 1)
             {
-                source = Source2;
+                source = MarshalInterface<IGraphicsEffectSource>.FromManaged(Source2);
                 return 0;
             }
             else
             {
-                source = null;
+                source = IntPtr.Zero;
                 return 2147483637;
             }
         }

--- a/MileXamlControlsDemoNetCore/UI/Backdrop/GaussianBlurEffect.cs
+++ b/MileXamlControlsDemoNetCore/UI/Backdrop/GaussianBlurEffect.cs
@@ -2,18 +2,16 @@
 using MileXamlControlsDemoNetCore.WindowsAPI.ComTypes;
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Windows.Graphics.Effects;
+using WinRT;
 
 namespace MileXamlControlsDemoNetCore.UI.Backdrop
 {
-    [Guid("1FEB6D69-2FE6-4AC9-8C58-1D7F93E7A6A5")]
-    public partial class GaussianBlurEffect : IGraphicsEffect, IGraphicsEffectSource, IGraphicsEffectD2D1Interop
+    [GeneratedComClass, Guid("1FEB6D69-2FE6-4AC9-8C58-1D7F93E7A6A5")]
+    public sealed partial class GaussianBlurEffect : IGraphicsEffect, IGraphicsEffectSource, IGraphicsEffectD2D1Interop
     {
-        public D2D1_BUFFER_PRECISION BufferPrecision { get; set; }
-
-        public bool CacheOutput { get; set; }
-
-        public IGraphicsEffectSource Source { get; set; }
+        public string Name { get; set; } = string.Empty;
 
         public float BlurAmount { get; set; } = 3.0f;
 
@@ -21,14 +19,7 @@ namespace MileXamlControlsDemoNetCore.UI.Backdrop
 
         public EffectBorderMode BorderMode { get; set; } = EffectBorderMode.Soft;
 
-        private string _name = string.Empty;
-
-        public string Name
-        {
-            get { return _name; }
-
-            set { _name = value; }
-        }
+        public IGraphicsEffectSource Source { get; set; }
 
         public int GetEffectId(out Guid id)
         {
@@ -36,9 +27,9 @@ namespace MileXamlControlsDemoNetCore.UI.Backdrop
             return 0;
         }
 
-        public int GetNamedPropertyMapping(IntPtr name, out uint index, out GRAPHICS_EFFECT_PROPERTY_MAPPING mapping)
+        public int GetNamedPropertyMapping(string name, out uint index, out GRAPHICS_EFFECT_PROPERTY_MAPPING mapping)
         {
-            switch (Marshal.PtrToStringUni(name))
+            switch (name)
             {
                 case nameof(BlurAmount):
                     {
@@ -112,16 +103,16 @@ namespace MileXamlControlsDemoNetCore.UI.Backdrop
             return 0;
         }
 
-        public int GetSource(uint index, out IGraphicsEffectSource source)
+        public int GetSource(uint index, out IntPtr source)
         {
             if (index is 0)
             {
-                source = Source;
+                source = MarshalInterface<IGraphicsEffectSource>.FromManaged(Source);
                 return 0;
             }
             else
             {
-                source = null;
+                source = IntPtr.Zero;
                 return 2147483637;
             }
         }

--- a/MileXamlControlsDemoNetCore/UI/Backdrop/OpacityEffect.cs
+++ b/MileXamlControlsDemoNetCore/UI/Backdrop/OpacityEffect.cs
@@ -2,29 +2,20 @@
 using MileXamlControlsDemoNetCore.WindowsAPI.ComTypes;
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Windows.Graphics.Effects;
+using WinRT;
 
 namespace MileXamlControlsDemoNetCore.UI.Backdrop
 {
-    [Guid("811D79A4-DE28-4454-8094-C64685F8BD4C")]
+    [GeneratedComClass, Guid("811D79A4-DE28-4454-8094-C64685F8BD4C")]
     public sealed partial class OpacityEffect : IGraphicsEffect, IGraphicsEffectSource, IGraphicsEffectD2D1Interop
     {
-        public D2D1_BUFFER_PRECISION BufferPrecision { get; set; }
-
-        public bool CacheOutput { get; set; }
+        public string Name { get; set; } = string.Empty;
 
         public float Opacity { get; set; } = 1.0f;
 
         public IGraphicsEffectSource Source { get; set; }
-
-        private string _name = string.Empty;
-
-        public string Name
-        {
-            get { return _name; }
-
-            set { _name = value; }
-        }
 
         public int GetEffectId(out Guid id)
         {
@@ -32,14 +23,9 @@ namespace MileXamlControlsDemoNetCore.UI.Backdrop
             return 0;
         }
 
-        public static bool IsSupported
+        public int GetNamedPropertyMapping(string name, out uint index, out GRAPHICS_EFFECT_PROPERTY_MAPPING mapping)
         {
-            get { return true; }
-        }
-
-        public int GetNamedPropertyMapping(IntPtr name, out uint index, out GRAPHICS_EFFECT_PROPERTY_MAPPING mapping)
-        {
-            switch (Marshal.PtrToStringUni(name))
+            switch (name)
             {
                 case nameof(Opacity):
                     {
@@ -80,9 +66,9 @@ namespace MileXamlControlsDemoNetCore.UI.Backdrop
             return 0;
         }
 
-        public int GetSource(uint index, out IGraphicsEffectSource source)
+        public int GetSource(uint index, out IntPtr source)
         {
-            source = Source;
+            source = MarshalInterface<IGraphicsEffectSource>.FromManaged(Source);
             return 0;
         }
 

--- a/MileXamlControlsDemoNetCore/WindowsAPI/ComTypes/IGraphicsEffectD2D1Interop.cs
+++ b/MileXamlControlsDemoNetCore/WindowsAPI/ComTypes/IGraphicsEffectD2D1Interop.cs
@@ -1,225 +1,29 @@
-﻿using MileXamlControlsDemoNetCore.WindowsAPI.ComTypes;
-using System;
-using System.Runtime.CompilerServices;
+﻿using System;
 using System.Runtime.InteropServices;
-using Windows.Graphics.Effects;
+using System.Runtime.InteropServices.Marshalling;
 using WinRT;
-using WinRT.Interop;
-
-namespace ABI.MileXamlControlsDemoNetCore.WindowsAPI.ComTypes
-{
-    public static class IGraphicsEffectD2D1InteropMethods
-    {
-        public static Guid IID { get; } = typeof(IGraphicsEffectD2D1Interop).GUID;
-        public static IntPtr AbiToProjectionVftablePtr { get; } = IGraphicsEffectD2D1Interop.Vftbl.InitVtbl();
-    }
-}
 
 namespace MileXamlControlsDemoNetCore.WindowsAPI.ComTypes
 {
-    [WindowsRuntimeType, Guid("2FC57384-A068-44D7-A331-30982FCF7177")]
+    [GeneratedComInterface, WindowsRuntimeType, Guid("2FC57384-A068-44D7-A331-30982FCF7177")]
     public partial interface IGraphicsEffectD2D1Interop
     {
+        [PreserveSig]
         int GetEffectId(out Guid id);
 
-        int GetNamedPropertyMapping(IntPtr name, out uint index, out GRAPHICS_EFFECT_PROPERTY_MAPPING mapping);
+        [PreserveSig]
+        int GetNamedPropertyMapping([MarshalAs(UnmanagedType.LPWStr)] string name, out uint index, out GRAPHICS_EFFECT_PROPERTY_MAPPING mapping);
 
+        [PreserveSig]
         int GetPropertyCount(out uint count);
 
+        [PreserveSig]
         int GetProperty(uint index, out IntPtr value);
 
-        int GetSource(uint index, out IGraphicsEffectSource source);
+        [PreserveSig]
+        int GetSource(uint index, out IntPtr source);
 
+        [PreserveSig]
         int GetSourceCount(out uint count);
-
-        internal unsafe struct Vftbl
-        {
-            public static IntPtr InitVtbl()
-            {
-                Vftbl* lpVtbl = (Vftbl*)ComWrappersSupport.AllocateVtableMemory(typeof(Vftbl), sizeof(Vftbl));
-
-                lpVtbl->IUnknownVftbl = IUnknownVftbl.AbiToProjectionVftbl;
-                lpVtbl->GetEffectId = &GetEffectIdFromAbi;
-                lpVtbl->GetNamedPropertyMapping = &GetNamedPropertyMappingFromAbi;
-                lpVtbl->GetPropertyCount = &GetPropertyCountFromAbi;
-                lpVtbl->GetProperty = &GetPropertyFromAbi;
-                lpVtbl->GetSource = &GetSourceFromAbi;
-                lpVtbl->GetSourceCount = &GetSourceCountFromAbi;
-                return (IntPtr)lpVtbl;
-            }
-
-            private IUnknownVftbl IUnknownVftbl;
-
-            // interface delegates
-            private delegate* unmanaged[MemberFunction]<IntPtr, Guid*, int> GetEffectId;
-
-            private delegate* unmanaged[MemberFunction]<IntPtr, IntPtr, uint*, GRAPHICS_EFFECT_PROPERTY_MAPPING*, int> GetNamedPropertyMapping;
-            private delegate* unmanaged[MemberFunction]<IntPtr, uint*, int> GetPropertyCount;
-            private delegate* unmanaged[MemberFunction]<IntPtr, uint, IntPtr*, int> GetProperty;
-            private delegate* unmanaged[MemberFunction]<IntPtr, uint, IntPtr*, int> GetSource;
-            private delegate* unmanaged[MemberFunction]<IntPtr, uint*, int> GetSourceCount;
-
-            // interface implementation
-            [UnmanagedCallersOnly(CallConvs = [typeof(CallConvMemberFunction)])]
-            private static int GetEffectIdFromAbi(IntPtr thisPtr, Guid* value)
-            {
-                try
-                {
-                    if (value != null)
-                    {
-                        *value = Guid.Empty;
-                    }
-
-                    int hr = ComWrappersSupport.FindObject<IGraphicsEffectD2D1Interop>(thisPtr).GetEffectId(out Guid v);
-                    if (hr >= 0)
-                    {
-                        if (value != null)
-                        {
-                            *value = v;
-                        }
-                    }
-                    return hr;
-                }
-                catch (Exception e)
-                {
-                    ExceptionHelpers.SetErrorInfo(e);
-                    return Marshal.GetHRForException(e);
-                }
-            }
-
-            [UnmanagedCallersOnly(CallConvs = [typeof(CallConvMemberFunction)])]
-            private static int GetNamedPropertyMappingFromAbi(IntPtr thisPtr, IntPtr name, uint* index, GRAPHICS_EFFECT_PROPERTY_MAPPING* mapping)
-            {
-                try
-                {
-                    if (index != null)
-                    {
-                        *index = 0;
-                    }
-
-                    if (mapping != null)
-                    {
-                        *mapping = 0;
-                    }
-
-                    int hr = ComWrappersSupport.FindObject<IGraphicsEffectD2D1Interop>(thisPtr).GetNamedPropertyMapping(name, out uint i, out GRAPHICS_EFFECT_PROPERTY_MAPPING m);
-                    if (hr >= 0)
-                    {
-                        if (index != null)
-                        {
-                            *index = i;
-                        }
-
-                        if (mapping != null)
-                        {
-                            *mapping = m;
-                        }
-                    }
-                    return hr;
-                }
-                catch (Exception e)
-                {
-                    ExceptionHelpers.SetErrorInfo(e);
-                    return Marshal.GetHRForException(e);
-                }
-            }
-
-            [UnmanagedCallersOnly(CallConvs = [typeof(CallConvMemberFunction)])]
-            private static int GetPropertyCountFromAbi(IntPtr thisPtr, uint* value)
-            {
-                try
-                {
-                    if (value != null)
-                    {
-                        *value = 0;
-                    }
-
-                    int hr = ComWrappersSupport.FindObject<IGraphicsEffectD2D1Interop>(thisPtr).GetPropertyCount(out uint v);
-                    if (hr >= 0)
-                    {
-                        *value = v;
-                    }
-                    return hr;
-                }
-                catch (Exception e)
-                {
-                    ExceptionHelpers.SetErrorInfo(e);
-                    return Marshal.GetHRForException(e);
-                }
-            }
-
-            [UnmanagedCallersOnly(CallConvs = [typeof(CallConvMemberFunction)])]
-            private static int GetPropertyFromAbi(IntPtr thisPtr, uint index, IntPtr* value)
-            {
-                try
-                {
-                    if (value != null)
-                    {
-                        *value = 0;
-                    }
-
-                    int hr = ComWrappersSupport.FindObject<IGraphicsEffectD2D1Interop>(thisPtr).GetProperty(index, out IntPtr v);
-                    if (hr >= 0)
-                    {
-                        *value = v;
-                    }
-                    return hr;
-                }
-                catch (Exception e)
-                {
-                    ExceptionHelpers.SetErrorInfo(e);
-                    return Marshal.GetHRForException(e);
-                }
-            }
-
-            [UnmanagedCallersOnly(CallConvs = [typeof(CallConvMemberFunction)])]
-            private static int GetSourceFromAbi(IntPtr thisPtr, uint index, IntPtr* value)
-            {
-                try
-                {
-                    if (value != null)
-                    {
-                        *value = 0;
-                    }
-
-                    int hr = ComWrappersSupport.FindObject<IGraphicsEffectD2D1Interop>(thisPtr).GetSource(index, out IGraphicsEffectSource v);
-                    if (hr >= 0)
-                    {
-                        IntPtr unk = MarshalInspectable<IGraphicsEffectSource>.FromManaged(v!);
-                        *value = unk;
-                    }
-                    return hr;
-                }
-                catch (Exception e)
-                {
-                    ExceptionHelpers.SetErrorInfo(e);
-                    return Marshal.GetHRForException(e);
-                }
-            }
-
-            [UnmanagedCallersOnly(CallConvs = [typeof(CallConvMemberFunction)])]
-            private static int GetSourceCountFromAbi(IntPtr thisPtr, uint* value)
-            {
-                try
-                {
-                    if (value != null)
-                    {
-                        *value = 0;
-                    }
-
-                    int hr = ComWrappersSupport.FindObject<IGraphicsEffectD2D1Interop>(thisPtr).GetSourceCount(out uint v);
-                    if (hr >= 0)
-                    {
-                        *value = v;
-                    }
-                    return hr;
-                }
-                catch (Exception e)
-                {
-                    ExceptionHelpers.SetErrorInfo(e);
-                    return Marshal.GetHRForException(e);
-                }
-            }
-        }
     }
 }

--- a/MileXamlControlsDemoNetCore/WindowsAPI/ComTypes/IGraphicsEffectD2D1InteropMethods.cs
+++ b/MileXamlControlsDemoNetCore/WindowsAPI/ComTypes/IGraphicsEffectD2D1InteropMethods.cs
@@ -1,0 +1,25 @@
+﻿using MileXamlControlsDemoNetCore.WindowsAPI.ComTypes;
+using System;
+using System.Reflection;
+using System.Runtime.InteropServices.Marshalling;
+
+// 抑制 IDE0130 警告
+#pragma warning disable IDE0130
+
+namespace ABI.MileXamlControlsDemoNetCore.WindowsAPI.ComTypes
+{
+    public static class IGraphicsEffectD2D1InteropMethods
+    {
+        public static Guid IID { get; } = typeof(IGraphicsEffectD2D1Interop).GUID;
+
+        public static IntPtr AbiToProjectionVftablePtr { get; }
+
+        static IGraphicsEffectD2D1InteropMethods()
+        {
+            unsafe
+            {
+                AbiToProjectionVftablePtr = (IntPtr)((IIUnknownDerivedDetails)typeof(IGraphicsEffectD2D1Interop).GetCustomAttribute(typeof(IUnknownDerivedAttribute<,>))).ManagedVirtualMethodTable;
+            }
+        }
+    }
+}


### PR DESCRIPTION
1. 使用 GeneratedComInterface 去定义 IGraphicsEffectD2D1Interop。
2. 是否需要立即合并：GeneratedComInterface 定义的接口不支持 CsWinRT 的异常处理，是否需要等待 CsWinRT 和 .NET 解决了相关问题后，再在原有的接口完善 CsWinRT 的异常处理功能？

相关问题和 PR 请求链接：
https://github.com/microsoft/CsWinRT/issues/1851
https://github.com/microsoft/CsWinRT/pull/1858